### PR TITLE
feat(backend): dispatch scoring service

### DIFF
--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from datetime import datetime, timezone
 from app.models.load import LoadRequest
 from app.services.navpro import get_drivers
-from app.services.claude import get_dispatch_recommendations, get_cost_insights
+from app.services.claude import get_cost_insights, enrich_recommendations_with_ai
 from app.services.eligibility import evaluate_driver_for_load
+from app.services.scoring import score_drivers
 from app.models.events import AssignmentDecisionEvent, AssignmentDecisionPayload
 from app.services.event_bus import event_bus
 from app.limiter import limiter
@@ -13,7 +14,11 @@ router = APIRouter(prefix="/dispatch", tags=["dispatch"])
 
 @router.post("/recommend")
 @limiter.limit("10/minute")
-async def recommend_dispatch(request: Request, req: LoadRequest):
+async def recommend_dispatch(
+    request: Request,
+    req: LoadRequest,
+    enrich_with_ai: bool = Query(default=False),
+):
     drivers, source = await get_drivers()
     evaluations = [
         evaluate_driver_for_load(driver, req.pickup, req.destination, req.cargo, req.weight_lbs)
@@ -45,15 +50,21 @@ async def recommend_dispatch(request: Request, req: LoadRequest):
                 "dispatch_note": "No eligible driver-truck pairs met the readiness, HOS, certification, and capacity checks.",
             },
             "source": source,
+            "scoring": "deterministic",
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
-    result = await get_dispatch_recommendations(
+    result = score_drivers(
         eligible_drivers, req.pickup, req.destination, req.cargo, req.weight_lbs
     )
+
+    if enrich_with_ai:
+        result = await enrich_recommendations_with_ai(result)
+
     return {
-        "data": result,
+        "data": result.model_dump(),
         "source": source,
+        "scoring": "deterministic",
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/backend/app/services/claude.py
+++ b/backend/app/services/claude.py
@@ -93,6 +93,69 @@ async def get_dispatch_recommendations(
         raise HTTPException(status_code=502, detail="AI service returned an unexpected response")
 
 
+async def enrich_recommendations_with_ai(
+    result: "DispatchRecommendation",
+) -> "DispatchRecommendation":
+    from app.models.ai import DispatchRecommendation, DriverRecommendation
+
+    if not result.recommendations:
+        return result
+
+    summary_lines = []
+    for rec in result.recommendations:
+        summary_lines.append(
+            f"- Rank {rec.rank}: {rec.driver_name} ({rec.driver_id}), "
+            f"score {rec.score}, {rec.distance_to_pickup_miles}mi deadhead, "
+            f"HOS {rec.hos_remaining_hrs}h, ${rec.cost_per_mile}/mi "
+            f"({rec.cost_delta_vs_avg:+.2f} vs avg). "
+            f"Scoring notes: {rec.reasoning}"
+        )
+    summary = "\n".join(summary_lines)
+
+    response = await client.messages.create(
+        model=MODEL,
+        max_tokens=512,
+        system=(
+            "You are Sauron, an AI dispatch intelligence. You are given deterministic scoring results "
+            "for driver-load matching. Rephrase each driver's scoring notes into a concise, natural-language "
+            "sentence a dispatcher would find useful. Do not change ranks or scores. "
+            "Return valid JSON only."
+        ),
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    f"Scoring results:\n{summary}\n\n"
+                    "Return JSON: {\"reasoning\": {\"<driver_id>\": \"One sentence.\", ...}}"
+                ),
+            }
+        ],
+    )
+
+    try:
+        raw = response.content[0].text.strip()
+        if raw.startswith("```"):
+            raw = raw.split("```", 2)[1]
+            if raw.startswith("json"):
+                raw = raw[4:]
+        data = json.loads(raw.strip())
+        reasoning_map = data.get("reasoning", {})
+    except (json.JSONDecodeError, IndexError, KeyError):
+        logger.warning("AI enrichment failed, keeping deterministic reasoning")
+        return result
+
+    enriched = []
+    for rec in result.recommendations:
+        if rec.driver_id in reasoning_map:
+            rec = rec.model_copy(update={"reasoning": reasoning_map[rec.driver_id]})
+        enriched.append(rec)
+
+    return DispatchRecommendation(
+        recommendations=enriched,
+        dispatch_note=result.dispatch_note,
+    )
+
+
 async def get_cost_insights(drivers: List[Driver]) -> dict:
     avg_cpm = sum(d.economics.cost_per_mile for d in drivers) / len(drivers)
     cost_rows = []

--- a/backend/app/services/scoring.py
+++ b/backend/app/services/scoring.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from app.models.ai import DispatchRecommendation, DriverRecommendation
+from app.models.driver import Driver
+from app.services.navpro import AVG_SPEED_MPH, haversine_miles, resolve_coords
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, value))
+
+
+@dataclass
+class ScoringWeights:
+    proximity: float = 0.30
+    hos_margin: float = 0.25
+    cost_efficiency: float = 0.20
+    readiness: float = 0.10
+    capacity_utilization: float = 0.10
+    fuel_adequacy: float = 0.05
+
+
+@dataclass
+class ScoringConfig:
+    weights: ScoringWeights = field(default_factory=ScoringWeights)
+    hos_surplus_ref_hrs: float = 4.0
+    max_results: int = 5
+
+
+@dataclass
+class _DriverFactors:
+    driver: Driver
+    deadhead_miles: float
+    haul_miles: float
+    estimated_hours: float
+    hos_surplus_hrs: float
+    factors: dict[str, float] = field(default_factory=dict)
+    score: int = 0
+
+
+def score_drivers(
+    drivers: List[Driver],
+    pickup: str,
+    destination: str,
+    cargo: str,
+    weight_lbs: int,
+    config: ScoringConfig | None = None,
+) -> DispatchRecommendation:
+    if config is None:
+        config = ScoringConfig()
+
+    if not drivers:
+        return DispatchRecommendation(
+            recommendations=[],
+            dispatch_note="No eligible drivers to score.",
+        )
+
+    pickup_coords = resolve_coords(pickup)
+    dest_coords = resolve_coords(destination)
+    haul_miles = haversine_miles(*pickup_coords, *dest_coords)
+
+    entries: list[_DriverFactors] = []
+    for driver in drivers:
+        driver_coords = (driver.location.lat, driver.location.lng)
+        deadhead = haversine_miles(*driver_coords, *pickup_coords)
+        total_miles = deadhead + haul_miles
+        estimated_hours = total_miles / AVG_SPEED_MPH
+        hos_surplus = driver.hos.drive_remaining_hrs - estimated_hours
+
+        entries.append(
+            _DriverFactors(
+                driver=driver,
+                deadhead_miles=deadhead,
+                haul_miles=haul_miles,
+                estimated_hours=estimated_hours,
+                hos_surplus_hrs=hos_surplus,
+            )
+        )
+
+    # Fleet-level stats for relative cost normalization
+    cpms = [e.driver.economics.cost_per_mile for e in entries]
+    min_cpm, max_cpm = min(cpms), max(cpms)
+    cpm_range = max_cpm - min_cpm
+
+    avg_cpm = sum(cpms) / len(cpms)
+
+    w = config.weights
+
+    for entry in entries:
+        d = entry.driver
+        max_dh = d.contract_constraints.max_deadhead_miles or 500.0
+
+        proximity = 1.0 - _clamp(entry.deadhead_miles / max_dh)
+        hos_margin = _clamp(entry.hos_surplus_hrs / config.hos_surplus_ref_hrs)
+        cost_eff = 1.0 - _clamp((d.economics.cost_per_mile - min_cpm) / cpm_range) if cpm_range > 0 else 1.0
+        readiness = _clamp(d.readiness.score / 100.0)
+        cap_util = _clamp(weight_lbs / d.vehicle.capacity_lbs) if d.vehicle.capacity_lbs > 0 else 0.0
+        fuel = _clamp(d.vehicle.fuel_level_pct / 100.0)
+
+        entry.factors = {
+            "proximity": proximity,
+            "hos_margin": hos_margin,
+            "cost_efficiency": cost_eff,
+            "readiness": readiness,
+            "capacity_utilization": cap_util,
+            "fuel_adequacy": fuel,
+        }
+
+        raw = (
+            w.proximity * proximity
+            + w.hos_margin * hos_margin
+            + w.cost_efficiency * cost_eff
+            + w.readiness * readiness
+            + w.capacity_utilization * cap_util
+            + w.fuel_adequacy * fuel
+        )
+        entry.score = round(raw * 100)
+
+    # Sort: score desc, cost asc, driver_id asc for deterministic tie-breaking
+    entries.sort(key=lambda e: (-e.score, e.driver.economics.cost_per_mile, e.driver.driver_id))
+
+    results = entries[: config.max_results]
+
+    recommendations: list[DriverRecommendation] = []
+    for rank, entry in enumerate(results, start=1):
+        d = entry.driver
+        cost_delta = d.economics.cost_per_mile - avg_cpm
+        reasoning = _build_reasoning(entry, avg_cpm)
+
+        recommendations.append(
+            DriverRecommendation(
+                rank=rank,
+                driver_id=d.driver_id,
+                driver_name=d.name,
+                score=entry.score,
+                distance_to_pickup_miles=round(entry.deadhead_miles, 1),
+                hos_remaining_hrs=round(d.hos.drive_remaining_hrs, 1),
+                cost_per_mile=d.economics.cost_per_mile,
+                cost_delta_vs_avg=round(cost_delta, 2),
+                reasoning=reasoning,
+            )
+        )
+
+    top = results[0] if results else None
+    if top and len(results) > 1:
+        spread = f"{results[0].score}-{results[-1].score}"
+        note = (
+            f"Scored {len(entries)} eligible drivers. "
+            f"Top pick: {top.driver.name} (score {top.score}). Spread: {spread}."
+        )
+    elif top:
+        note = f"Single eligible driver: {top.driver.name} (score {top.score})."
+    else:
+        note = "No eligible drivers to score."
+
+    return DispatchRecommendation(recommendations=recommendations, dispatch_note=note)
+
+
+def _build_reasoning(entry: _DriverFactors, avg_cpm: float) -> str:
+    d = entry.driver
+    factor_labels = {
+        "proximity": f"{entry.deadhead_miles:.0f}mi deadhead",
+        "hos_margin": f"{entry.hos_surplus_hrs:.1f}h HOS surplus",
+        "cost_efficiency": f"${d.economics.cost_per_mile:.2f}/mi",
+        "readiness": f"readiness {d.readiness.score}/100",
+        "capacity_utilization": f"{entry.factors['capacity_utilization'] * 100:.0f}% capacity used",
+        "fuel_adequacy": f"fuel at {d.vehicle.fuel_level_pct:.0f}%",
+    }
+
+    # Sort factors by weighted contribution descending
+    weights = ScoringWeights()
+    weighted = sorted(
+        entry.factors.items(),
+        key=lambda kv: kv[1] * getattr(weights, kv[0]),
+        reverse=True,
+    )
+
+    top_name = weighted[0][0]
+    parts = [f"Top factor: {top_name.replace('_', ' ')} ({factor_labels[top_name]})"]
+
+    if len(weighted) > 1:
+        second_name = weighted[1][0]
+        parts.append(factor_labels[second_name])
+
+    total_miles = entry.deadhead_miles + entry.haul_miles
+    parts.append(f"est. {total_miles:.0f} total miles")
+
+    return ". ".join(parts) + "."


### PR DESCRIPTION
## Summary

- Adds a deterministic scoring service (`scoring.py`) that replaces AI-only dispatch ranking with a reproducible, weighted formula across 6 factors: proximity, HOS margin, cost efficiency, readiness, capacity utilization, and fuel adequacy
- Scores are auditable and reproducible for the same inputs, with explainable reasoning strings built from factor contributions
- AI narrative enrichment is available opt-in via `?enrich_with_ai=true` query param — Claude rephrases reasoning without changing scores or ranks
- No frontend changes needed — same `DriverRecommendation` response shape

## Test plan
- [ ] `POST /dispatch/recommend` returns deterministic scores (0-100) with
   reasoning
- [ ] Same request twice produces identical rankings and scores
- [ ] `?enrich_with_ai=true` enriches reasoning via Claude without altering scores
- [ ] Ineligible drivers are excluded before scoring (existing eligibility layer)
- [ ] Frontend dispatch panel renders results unchanged

---

Closes #8