### PR TITLE
Enhance receiver notifications and frontend support

### DIFF
--- a/backend/app/models/domain.py
+++ b/backend/app/models/domain.py
@@ -375,11 +375,15 @@ class ReceiverNotification(AuditFields):
     receiver_notification_id: str
     consignment_id: str
     assignment_id: Optional[str] = None
+    notification_type: str = "manual"
     channel: NotificationChannel
     recipient: str
     sent_at: datetime
     delivery_status: str
+    eta_at: Optional[datetime] = None
     message_template: Optional[str] = None
+    message_text: Optional[str] = None
+    context: dict = Field(default_factory=dict)
     external_reference: Optional[str] = None
 
 

--- a/backend/app/routers/operations.py
+++ b/backend/app/routers/operations.py
@@ -11,6 +11,7 @@ from app.services.operations import (
     delete_consignment,
     get_consignment,
     get_consignment_timeline,
+    list_receiver_notifications,
     list_assignments,
     list_consignments,
     update_consignment,
@@ -184,6 +185,33 @@ async def get_consignment_events(
 
     return {
         "data": timeline,
+        "fleet_id": fleet_id,
+        "source": "insforge",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/consignments/{consignment_id}/notifications")
+async def get_consignment_notifications(
+    consignment_id: str,
+    fleet_id: str = Query(...),
+):
+    try:
+        consignment = await get_consignment(fleet_id=fleet_id, consignment_id=consignment_id)
+        if not consignment:
+            raise HTTPException(status_code=404, detail="Consignment not found")
+        notifications = await list_receiver_notifications(
+            fleet_id=fleet_id,
+            consignment_id=consignment_id,
+        )
+    except OperationsServiceNotConfigured as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except OperationsServiceError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    return {
+        "data": notifications,
+        "count": len(notifications),
         "fleet_id": fleet_id,
         "source": "insforge",
         "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/backend/app/services/event_consumers.py
+++ b/backend/app/services/event_consumers.py
@@ -7,10 +7,12 @@ from app.models.events import (
     BreakdownEvent,
     FleetEvent,
     HOSThresholdWarningEvent,
+    ReceiverNotificationEvent,
     RouteDeviationEvent,
     TelemetryUpdateEvent,
 )
 from app.services.event_bus import FleetEventBus
+from app.services.operations import create_route_event_notification
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +68,49 @@ async def _watch_route_deviations(event: FleetEvent) -> None:
         event.payload.deviation_miles,
         event.payload.corridor,
     )
+    await create_route_event_notification(
+        fleet_id=event.fleet_id,
+        assignment_id=event.payload.assignment_id,
+        driver_id=event.payload.driver_id,
+        notification_type="route_impact_alert",
+        reason=f"{event.payload.severity} route deviation in {event.payload.corridor}",
+        eta_shift_minutes=45 if event.payload.severity == "major" else 20,
+        extra_context={
+            "deviation_miles": event.payload.deviation_miles,
+            "corridor": event.payload.corridor,
+            "severity": event.payload.severity,
+            "lat": event.payload.lat,
+            "lng": event.payload.lng,
+        },
+    )
+
+
+async def _watch_breakdown_notifications(event: FleetEvent) -> None:
+    if not isinstance(event, BreakdownEvent):
+        return
+    await create_route_event_notification(
+        fleet_id=event.fleet_id,
+        assignment_id=None,
+        driver_id=event.payload.driver_id,
+        notification_type="exception_alert",
+        reason=event.payload.summary,
+        eta_shift_minutes=90 if event.payload.severity in {"high", "critical"} else 45,
+        extra_context={
+            "severity": event.payload.severity,
+            "truck_id": event.payload.truck_id,
+        },
+    )
+
+
+async def _watch_receiver_notifications(event: FleetEvent) -> None:
+    if not isinstance(event, ReceiverNotificationEvent):
+        return
+    logger.info(
+        "receiver notification %s -> %s [%s]",
+        event.payload.consignment_id,
+        event.payload.recipient,
+        event.payload.status,
+    )
 
 
 def register_core_consumers(bus: FleetEventBus) -> None:
@@ -77,5 +122,8 @@ def register_core_consumers(bus: FleetEventBus) -> None:
     bus.register_handler("hos.threshold_warning.v1", _watch_hos_alerts)
     bus.register_handler("breakdown.reported.v1", _log_event)
     bus.register_handler("breakdown.reported.v1", _watch_breakdowns)
+    bus.register_handler("breakdown.reported.v1", _watch_breakdown_notifications)
     bus.register_handler("route.deviation_detected.v1", _log_event)
     bus.register_handler("route.deviation_detected.v1", _watch_route_deviations)
+    bus.register_handler("receiver.notification_sent.v1", _log_event)
+    bus.register_handler("receiver.notification_sent.v1", _watch_receiver_notifications)

--- a/backend/app/services/operations.py
+++ b/backend/app/services/operations.py
@@ -13,6 +13,8 @@ from app.models.domain import (
     ConsignmentUpdate,
     can_transition_consignment_status,
 )
+from app.models.events import ReceiverNotificationEvent, ReceiverNotificationPayload
+from app.services.event_bus import event_bus
 
 
 class OperationsServiceError(Exception):
@@ -132,6 +134,10 @@ def _generate_consignment_id() -> str:
     return f"CON{uuid4().hex[:8].upper()}"
 
 
+def _generate_receiver_notification_id() -> str:
+    return f"RNT{uuid4().hex[:8].upper()}"
+
+
 def _flatten_consignment_payload(payload: ConsignmentCreate | ConsignmentUpdate) -> dict[str, Any]:
     values = payload.model_dump(exclude_none=True, mode="json")
     pickup_window = values.pop("pickup_window", None)
@@ -145,6 +151,298 @@ def _flatten_consignment_payload(payload: ConsignmentCreate | ConsignmentUpdate)
         values["delivery_window_end_at"] = delivery_window["end_at"]
 
     return values
+
+
+def _coalesce_eta(row: dict[str, Any]) -> str | None:
+    return (
+        row.get("promised_delivery_at")
+        or row.get("delivery_window_end_at")
+        or row.get("delivery_window_start_at")
+    )
+
+
+def _to_display_timestamp(value: str | None) -> str:
+    if not value:
+        return "TBD"
+    parsed = _parse_timestamp(value)
+    if not parsed:
+        return "TBD"
+    return parsed.astimezone(timezone.utc).strftime("%b %d %I:%M %p UTC")
+
+
+def _build_message_text(
+    *,
+    consignment: dict[str, Any],
+    notification_type: str,
+    eta_at: str | None,
+    context: dict[str, Any],
+) -> str:
+    consignment_id = consignment.get("consignment_id", "shipment")
+    destination = consignment.get("destination", "destination")
+    receiver_name = consignment.get("receiver_name", "receiver")
+    driver_id = consignment.get("assigned_driver_id")
+    event_timestamp = _to_display_timestamp(context.get("event_timestamp"))
+    eta_display = _to_display_timestamp(eta_at)
+
+    if notification_type == "assignment_confirmed":
+        driver_note = f" Driver {driver_id} has been assigned." if driver_id else ""
+        return (
+            f"Shipment {consignment_id} for {receiver_name} is now assigned and scheduled to "
+            f"{destination}.{driver_note} Current ETA: {eta_display}."
+        )
+    if notification_type == "dispatched":
+        return (
+            f"Shipment {consignment_id} has departed origin and is en route to {destination}. "
+            f"Dispatch timestamp: {event_timestamp}. ETA: {eta_display}."
+        )
+    if notification_type == "in_transit_update":
+        return (
+            f"Shipment {consignment_id} remains in transit to {destination}. "
+            f"Latest ETA as of {event_timestamp}: {eta_display}."
+        )
+    if notification_type == "eta_updated":
+        previous_eta = _to_display_timestamp(context.get("previous_eta_at"))
+        return (
+            f"Shipment {consignment_id} ETA changed from {previous_eta} to {eta_display}. "
+            f"Update recorded at {event_timestamp}."
+        )
+    if notification_type == "delay_alert":
+        return (
+            f"Shipment {consignment_id} is delayed en route to {destination}. "
+            f"Updated ETA: {eta_display}. Context: {context.get('reason', 'operational delay')}."
+        )
+    if notification_type == "exception_alert":
+        return (
+            f"Shipment {consignment_id} hit an in-transit exception affecting delivery to {destination}. "
+            f"Updated ETA: {eta_display}. Context: {context.get('reason', 'dispatcher review in progress')}."
+        )
+    if notification_type == "route_impact_alert":
+        return (
+            f"Shipment {consignment_id} encountered a route-impacting event while moving to {destination}. "
+            f"Updated ETA: {eta_display}. Context: {context.get('reason', 'route deviation detected')}."
+        )
+    if notification_type == "delivered":
+        return (
+            f"Shipment {consignment_id} has been delivered to {destination}. "
+            f"Completion timestamp: {event_timestamp}."
+        )
+
+    return (
+        f"Shipment {consignment_id} has a new receiver update for {destination}. "
+        f"Current ETA: {eta_display}."
+    )
+
+
+async def _publish_receiver_notification_events(
+    *,
+    consignment_id: str,
+    notifications: list[dict[str, Any]],
+) -> None:
+    for notification in notifications:
+        await event_bus.publish(
+            ReceiverNotificationEvent(
+                producer="operations.receiver_notifications",
+                payload=ReceiverNotificationPayload(
+                    consignment_id=consignment_id,
+                    channel=notification.get("channel", "portal"),
+                    recipient=notification.get("recipient", ""),
+                    status=notification.get("delivery_status", "sent"),
+                ),
+            )
+        )
+
+
+async def create_receiver_notifications(
+    *,
+    fleet_id: str,
+    consignment: dict[str, Any],
+    notification_type: str,
+    event_timestamp: str | None = None,
+    eta_at: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    preferences = consignment.get("receiver_contact_preferences") or []
+    if not preferences:
+        return []
+
+    sent_at = event_timestamp or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    eta_at = eta_at or _coalesce_eta(consignment)
+    context = {
+        **(context or {}),
+        "event_timestamp": event_timestamp or sent_at,
+        "notification_type": notification_type,
+    }
+
+    rows: list[dict[str, Any]] = []
+    for preference in preferences:
+        rows.append(
+            {
+                "receiver_notification_id": _generate_receiver_notification_id(),
+                "fleet_id": fleet_id,
+                "consignment_id": consignment["consignment_id"],
+                "assignment_id": consignment.get("current_assignment_id"),
+                "notification_type": notification_type,
+                "channel": preference.get("channel", "portal"),
+                "recipient": preference.get("recipient", ""),
+                "sent_at": sent_at,
+                "delivery_status": "sent",
+                "eta_at": eta_at,
+                "message_template": notification_type,
+                "message_text": _build_message_text(
+                    consignment=consignment,
+                    notification_type=notification_type,
+                    eta_at=eta_at,
+                    context=context,
+                ),
+                "context": context,
+                "external_reference": f"{notification_type}:{uuid4().hex[:10]}",
+            }
+        )
+
+    created = await _mutate_records("POST", "receiver_notifications", json_body=rows)
+    if isinstance(created, list):
+        await _publish_receiver_notification_events(
+            consignment_id=consignment["consignment_id"],
+            notifications=created,
+        )
+        return created
+
+    await _publish_receiver_notification_events(
+        consignment_id=consignment["consignment_id"],
+        notifications=rows,
+    )
+    return rows
+
+
+async def list_receiver_notifications(
+    fleet_id: str,
+    consignment_id: str,
+) -> list[dict[str, Any]]:
+    return await _fetch_records(
+        "receiver_notifications",
+        {
+            "fleet_id": f"eq.{fleet_id}",
+            "consignment_id": f"eq.{consignment_id}",
+            "order": "sent_at.desc",
+        },
+    )
+
+
+def _estimate_eta_shift(
+    *,
+    base_eta: str | None,
+    minutes: int,
+) -> str | None:
+    parsed = _parse_timestamp(base_eta)
+    if not parsed:
+        return None
+    shifted = parsed.timestamp() + (minutes * 60)
+    return datetime.fromtimestamp(shifted, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _emit_consignment_notifications_for_update(
+    *,
+    fleet_id: str,
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    updated_fields: dict[str, Any],
+) -> None:
+    current_status = current.get("status")
+    previous_status = previous.get("status")
+    previous_eta = _coalesce_eta(previous)
+    current_eta = _coalesce_eta(current)
+    event_timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    if previous_status != current_status:
+        status_to_notification = {
+            "dispatched": "dispatched",
+            "in_transit": "in_transit_update",
+            "delayed": "delay_alert",
+            "exception": "exception_alert",
+            "delivered": "delivered",
+        }
+        notification_type = status_to_notification.get(current_status)
+        if notification_type:
+            await create_receiver_notifications(
+                fleet_id=fleet_id,
+                consignment=current,
+                notification_type=notification_type,
+                event_timestamp=event_timestamp,
+                eta_at=current_eta,
+                context={
+                    "previous_status": previous_status,
+                    "current_status": current_status,
+                    "reason": updated_fields.get("status"),
+                },
+            )
+
+    if previous_eta != current_eta and current_eta:
+        await create_receiver_notifications(
+            fleet_id=fleet_id,
+            consignment=current,
+            notification_type="eta_updated",
+            event_timestamp=event_timestamp,
+            eta_at=current_eta,
+            context={
+                "previous_eta_at": previous_eta,
+                "current_eta_at": current_eta,
+            },
+        )
+
+
+async def create_route_event_notification(
+    *,
+    fleet_id: str,
+    assignment_id: str | None,
+    driver_id: str | None,
+    notification_type: str,
+    reason: str,
+    eta_shift_minutes: int = 0,
+    extra_context: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    consignment: dict[str, Any] | None = None
+
+    if assignment_id:
+        assignment_rows = await _fetch_records(
+            "assignments",
+            {
+                "fleet_id": f"eq.{fleet_id}",
+                "assignment_id": f"eq.{assignment_id}",
+                "limit": "1",
+            },
+        )
+        if assignment_rows:
+            consignment_id = assignment_rows[0].get("consignment_id")
+            if consignment_id:
+                consignment = await get_consignment(fleet_id=fleet_id, consignment_id=consignment_id)
+
+    if not consignment and driver_id:
+        consignment_rows = await _fetch_records(
+            "consignments",
+            {
+                "fleet_id": f"eq.{fleet_id}",
+                "assigned_driver_id": f"eq.{driver_id}",
+                "status": "in.(assigned,dispatched,in_transit,delayed,exception)",
+                "order": "updated_at.desc",
+                "limit": "1",
+            },
+        )
+        consignment = consignment_rows[0] if consignment_rows else None
+
+    if not consignment:
+        return []
+
+    eta_at = _estimate_eta_shift(base_eta=_coalesce_eta(consignment), minutes=eta_shift_minutes)
+    return await create_receiver_notifications(
+        fleet_id=fleet_id,
+        consignment=consignment,
+        notification_type=notification_type,
+        eta_at=eta_at or _coalesce_eta(consignment),
+        context={
+            "reason": reason,
+            **(extra_context or {}),
+        },
+    )
 
 
 async def list_consignments(
@@ -236,8 +534,19 @@ async def update_consignment(
         json_body=values,
     )
     if isinstance(updated, list) and updated:
-        return updated[0]
-    return await get_consignment(fleet_id=fleet_id, consignment_id=consignment_id)
+        updated_row = updated[0]
+    else:
+        updated_row = await get_consignment(fleet_id=fleet_id, consignment_id=consignment_id)
+
+    if updated_row:
+        await _emit_consignment_notifications_for_update(
+            fleet_id=fleet_id,
+            previous=existing,
+            current=updated_row,
+            updated_fields=values,
+        )
+
+    return updated_row
 
 
 async def delete_consignment(
@@ -309,6 +618,20 @@ async def create_assignment(
             "updated_at": now,
         },
     )
+
+    assigned_consignment = await get_consignment(fleet_id=fleet_id, consignment_id=consignment_id)
+    if assigned_consignment:
+        await create_receiver_notifications(
+            fleet_id=fleet_id,
+            consignment=assigned_consignment,
+            notification_type="assignment_confirmed",
+            event_timestamp=now,
+            context={
+                "dispatcher_id": dispatcher_id,
+                "driver_id": driver_id,
+                "truck_id": truck_id,
+            },
+        )
 
     if isinstance(created, list) and created:
         return created[0]

--- a/backend/insforge/migrations/004_receiver_notification_enrichment.sql
+++ b/backend/insforge/migrations/004_receiver_notification_enrichment.sql
@@ -1,0 +1,11 @@
+alter table receiver_notifications
+  add column if not exists notification_type text not null default 'manual',
+  add column if not exists eta_at timestamptz,
+  add column if not exists message_text text,
+  add column if not exists context jsonb not null default '{}'::jsonb;
+
+create index if not exists idx_receiver_notifications_fleet_sent_at
+  on receiver_notifications (fleet_id, sent_at desc);
+
+create index if not exists idx_receiver_notifications_assignment
+  on receiver_notifications (assignment_id);

--- a/backend/tests/test_operations_router.py
+++ b/backend/tests/test_operations_router.py
@@ -116,6 +116,39 @@ class OperationsRouterTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["data"]["consignment_id"], "CON001")
 
+    def test_get_consignment_notifications_returns_history(self):
+        mocked_row = {
+            "consignment_id": "CON001",
+            "fleet_id": "fleet_demo",
+            "status": "in_transit",
+        }
+        mocked_notifications = [
+            {
+                "receiver_notification_id": "RNT001",
+                "consignment_id": "CON001",
+                "notification_type": "eta_updated",
+                "delivery_status": "sent",
+            }
+        ]
+
+        with patch.object(
+            operations_module,
+            "get_consignment",
+            new=AsyncMock(return_value=mocked_row),
+        ), patch.object(
+            operations_module,
+            "list_receiver_notifications",
+            new=AsyncMock(return_value=mocked_notifications),
+        ):
+            response = self.client.get(
+                "/operations/consignments/CON001/notifications",
+                params={"fleet_id": "fleet_demo"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["data"][0]["receiver_notification_id"], "RNT001")
+
     def test_create_consignment_returns_created_envelope(self):
         mocked_row = {
             "consignment_id": "CONNEW1",

--- a/backend/tests/test_operations_service.py
+++ b/backend/tests/test_operations_service.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 from app.models.domain import ConsignmentCreate, ConsignmentUpdate, ConsignmentStatus
 from app.services.operations import (
     OperationsServiceConflict,
+    create_assignment,
     create_consignment,
     list_consignments,
     update_consignment,
@@ -87,6 +88,85 @@ class OperationsServiceTests(unittest.IsolatedAsyncioTestCase):
                     consignment_id="CON001",
                     payload=ConsignmentUpdate(status=ConsignmentStatus.unassigned),
                 )
+
+    async def test_create_assignment_creates_receiver_notifications(self):
+        consignment = {
+            "consignment_id": "CON001",
+            "fleet_id": "fleet_demo",
+            "receiver_name": "Mock Receiver",
+            "destination": "Dallas, TX",
+            "assigned_driver_id": "DRV001",
+            "current_assignment_id": "ASN001",
+            "receiver_contact_preferences": [
+                {"channel": "sms", "recipient": "+15555550101", "priority": 1}
+            ],
+            "promised_delivery_at": "2026-04-19T18:00:00Z",
+        }
+
+        with patch(
+            "app.services.operations._mutate_records",
+            new=AsyncMock(return_value=[{"assignment_id": "ASN001", "fleet_id": "fleet_demo"}]),
+        ), patch(
+            "app.services.operations.get_consignment",
+            new=AsyncMock(return_value=consignment),
+        ), patch(
+            "app.services.operations.create_receiver_notifications",
+            new=AsyncMock(return_value=[]),
+        ) as mock_notifications:
+            await create_assignment(
+                fleet_id="fleet_demo",
+                consignment_id="CON001",
+                dispatcher_id="DISP001",
+                driver_id="DRV001",
+                truck_id="TRK001",
+            )
+
+        mock_notifications.assert_awaited_once()
+        self.assertEqual(
+            mock_notifications.await_args.kwargs["notification_type"],
+            "assignment_confirmed",
+        )
+
+    async def test_update_consignment_emits_status_and_eta_notifications(self):
+        existing = {
+            "consignment_id": "CON001",
+            "fleet_id": "fleet_demo",
+            "status": "in_transit",
+            "promised_delivery_at": "2026-04-19T17:00:00Z",
+            "receiver_contact_preferences": [
+                {"channel": "sms", "recipient": "+15555550101", "priority": 1}
+            ],
+        }
+        updated = {
+            **existing,
+            "status": "delayed",
+            "promised_delivery_at": "2026-04-19T19:15:00Z",
+        }
+
+        with patch(
+            "app.services.operations.get_consignment",
+            new=AsyncMock(side_effect=[existing, updated]),
+        ), patch(
+            "app.services.operations._mutate_records",
+            new=AsyncMock(return_value=[updated]),
+        ), patch(
+            "app.services.operations.create_receiver_notifications",
+            new=AsyncMock(return_value=[]),
+        ) as mock_notifications:
+            await update_consignment(
+                fleet_id="fleet_demo",
+                consignment_id="CON001",
+                payload=ConsignmentUpdate(
+                    status=ConsignmentStatus.delayed,
+                    promised_delivery_at="2026-04-19T19:15:00Z",
+                ),
+            )
+
+        self.assertEqual(mock_notifications.await_count, 2)
+        notification_types = [
+            call.kwargs["notification_type"] for call in mock_notifications.await_args_list
+        ]
+        self.assertEqual(notification_types, ["delay_alert", "eta_updated"])
 
 
 if __name__ == "__main__":

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   ChatMessage,
   Consignment,
   ConsignmentPayload,
+  ReceiverNotification,
   TelemetryPosition,
   RouteDeviation,
   GeoJSONFeature,
@@ -230,6 +231,21 @@ export async function fetchConsignmentById(params: {
   const search = new URLSearchParams({ fleet_id: params.fleetId })
   return requestOperations(
     `${operationsBaseUrl}/operations/consignments/${params.consignmentId}?${search.toString()}`,
+    {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    },
+  )
+}
+
+export async function fetchConsignmentNotifications(params: {
+  fleetId: string
+  consignmentId: string
+}): Promise<{ data: ReceiverNotification[]; count: number; fleet_id: string }> {
+  const search = new URLSearchParams({ fleet_id: params.fleetId })
+  return requestOperations(
+    `${operationsBaseUrl}/operations/consignments/${params.consignmentId}/notifications?${search.toString()}`,
     {
       method: 'GET',
       headers: { Accept: 'application/json' },

--- a/frontend/src/components/dispatch/ConsignmentEditor.tsx
+++ b/frontend/src/components/dispatch/ConsignmentEditor.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
-import { ArrowLeft, Plus, Save, Trash2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { ArrowLeft, BellRing, Clock3, Plus, Save, Trash2 } from 'lucide-react'
+import { fetchConsignmentNotifications } from '../../api/client'
 import type {
   CargoClass,
   Consignment,
@@ -7,6 +8,7 @@ import type {
   ConsignmentPayload,
   ConsignmentStatus,
   NotificationChannel,
+  ReceiverNotification,
 } from '../../types'
 
 const cargoClassOptions: CargoClass[] = ['general', 'hazmat', 'refrigerated', 'oversized', 'high_value']
@@ -41,6 +43,20 @@ function toDateTimeLocal(value: string | null) {
 function toIsoOrNull(value: string) {
   if (!value) return null
   return new Date(value).toISOString()
+}
+
+function formatNotificationTimestamp(value: string | null) {
+  if (!value) return 'TBD'
+  return new Date(value).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function formatNotificationLabel(notificationType: string) {
+  return notificationType.replace(/_/g, ' ')
 }
 
 function createDefaultState(dispatchDate: string): FormState {
@@ -112,6 +128,9 @@ export function ConsignmentEditor({
   onDelete,
 }: ConsignmentEditorProps) {
   const [formState, setFormState] = useState<FormState>(() => stateFromConsignment(consignment, dispatchDate))
+  const [notifications, setNotifications] = useState<ReceiverNotification[]>([])
+  const [isLoadingNotifications, setIsLoadingNotifications] = useState(false)
+  const [notificationError, setNotificationError] = useState<string | null>(null)
 
   const isEditing = Boolean(consignment)
   const title = isEditing ? consignment?.consignment_id : 'New Consignment'
@@ -202,6 +221,44 @@ export function ConsignmentEditor({
   function updateField<Key extends keyof FormState>(key: Key, value: FormState[Key]) {
     setFormState((current) => ({ ...current, [key]: value }))
   }
+
+  useEffect(() => {
+    if (!consignment?.consignment_id) {
+      return
+    }
+
+    let cancelled = false
+
+    async function loadNotifications() {
+      setIsLoadingNotifications(true)
+      setNotificationError(null)
+      try {
+        const response = await fetchConsignmentNotifications({
+          fleetId: consignment.fleet_id,
+          consignmentId: consignment.consignment_id,
+        })
+        if (!cancelled) {
+          setNotifications(response.data)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setNotificationError(
+            error instanceof Error ? error.message : 'Unable to load receiver notification history',
+          )
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingNotifications(false)
+        }
+      }
+    }
+
+    loadNotifications()
+
+    return () => {
+      cancelled = true
+    }
+  }, [consignment?.consignment_id, consignment?.fleet_id])
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -467,6 +524,77 @@ export function ConsignmentEditor({
             ))}
           </div>
         </div>
+
+        {isEditing && (
+          <div className="rounded-2xl border border-[#dadce0] bg-[#f8f9fa] p-3">
+            <div className="mb-3 flex items-center justify-between">
+              <div className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#5f6368]">
+                <BellRing size={13} />
+                Receiver Notifications
+              </div>
+              <div className="text-[11px] text-[#5f6368]">
+                {notifications.length} sent updates
+              </div>
+            </div>
+
+            {isLoadingNotifications && (
+              <div className="rounded-xl border border-[#dadce0] bg-white px-3 py-3 text-xs text-[#5f6368]">
+                Loading notification history...
+              </div>
+            )}
+
+            {!isLoadingNotifications && notificationError && (
+              <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-3 text-xs text-red-700">
+                {notificationError}
+              </div>
+            )}
+
+            {!isLoadingNotifications && !notificationError && notifications.length === 0 && (
+              <div className="rounded-xl border border-dashed border-[#dadce0] bg-white px-3 py-4 text-xs text-[#5f6368]">
+                No receiver updates have been sent yet. Assignment, ETA, delay, and delivery changes will appear here automatically.
+              </div>
+            )}
+
+            {!isLoadingNotifications && !notificationError && notifications.length > 0 && (
+              <div className="space-y-3">
+                {notifications.map((notification) => (
+                  <div
+                    key={notification.receiver_notification_id}
+                    className="rounded-xl border border-[#dadce0] bg-white p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-medium text-[#202124]">
+                          {formatNotificationLabel(notification.notification_type)}
+                        </div>
+                        <div className="mt-1 text-xs text-[#5f6368]">
+                          {notification.channel.toUpperCase()} to {notification.recipient}
+                        </div>
+                      </div>
+                      <span className="rounded-full bg-[#e8f0fe] px-2 py-1 text-[11px] font-medium text-[#1a73e8]">
+                        {notification.delivery_status}
+                      </span>
+                    </div>
+
+                    {notification.message_text && (
+                      <p className="mt-3 text-sm leading-6 text-[#202124]">{notification.message_text}</p>
+                    )}
+
+                    <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-[#5f6368]">
+                      <span className="inline-flex items-center gap-1">
+                        <Clock3 size={12} />
+                        Sent {formatNotificationTimestamp(notification.sent_at)}
+                      </span>
+                      {notification.eta_at && (
+                        <span>ETA {formatNotificationTimestamp(notification.eta_at)}</span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </form>
 
       <div className="border-t border-[#dadce0] px-4 py-3 shrink-0">

--- a/frontend/src/components/dispatch/DispatchWorkspace.tsx
+++ b/frontend/src/components/dispatch/DispatchWorkspace.tsx
@@ -206,7 +206,7 @@ export function DispatchWorkspace() {
         {dispatchMode === 'board' ? (
           selectedConsignmentId === '__new__' || selectedConsignment ? (
             <ConsignmentEditor
-              key={`${selectedConsignmentId ?? 'board'}-${selectedDispatchDate}`}
+              key={`${selectedConsignmentId ?? 'board'}-${selectedDispatchDate}-${refreshKey}`}
               consignment={selectedConsignment}
               dispatchDate={selectedDispatchDate}
               isSaving={isSavingConsignment}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -194,6 +194,25 @@ export interface ConsignmentPayload {
   receiver_contact_preferences: ConsignmentContactPreference[]
 }
 
+export interface ReceiverNotification {
+  receiver_notification_id: string
+  fleet_id: string
+  consignment_id: string
+  assignment_id: string | null
+  notification_type: string
+  channel: NotificationChannel
+  recipient: string
+  sent_at: string
+  delivery_status: string
+  eta_at: string | null
+  message_template: string | null
+  message_text: string | null
+  context: Record<string, unknown>
+  external_reference: string | null
+  created_at: string
+  updated_at: string
+}
+
 export type OrchestrationDecision = 'auto_assigned' | 'needs_review' | 'no_match'
 
 export interface AssignmentPlan {


### PR DESCRIPTION
### Overview

#### Backend
- enrich receiver notification records with notif type, ETA, message
  text, and context metadata
- create receiver notifs automatically in assignment creation and
  consignment status/ETA updates
- trigger route-impacting and exception notifs for event consumers
- add on operations endpoint to fetch notif history per consignment

#### Frontend
- add frontend types and API client support for consignment
  notifications
- render a receiver notif history panel in the consignment editor
- show sent time, ETA, recipient, status, and generated message text
- refresh the editor view after saves so new notification history
  appears

#### Manual localhost verification
1. Apply the new migration so receiver_notifications has the added columns from `backend/insforge/migrations/004_receiver_notification_enrichment.sql`.
2. Start the backend `uvicorn main:app --reload --port 8000`.
3. Start the frontend with `pnpm dev`.
4. Open the dispatch workspace, select or create a consignment with at least one receiver contact preference, then assign it or change its status/ETA to dispatched, in_transit, delayed, exception, or delivered.
5. Reopen that consignment in the editor and confirm the new “Receiver Notifications” section shows sent entries with type, recipient, sent time, ETA, and generated message text.
6. You can also hit `GET /operations/consignments/{consignment_id}/notifications?fleet_id=fleet_demo` directly and verify rows are being returned from the backend.
7. For exception-driven behavior, trigger a route deviation or breakdown event in your local flow and confirm a new notification row appears for the active consignment tied to that driver/assignment.

---

rel: #12 